### PR TITLE
Use home_url instead of siteurl when checking for external images.

### DIFF
--- a/import-external-images.php
+++ b/import-external-images.php
@@ -410,7 +410,7 @@ function external_image_getext( $file ) {
 function external_image_get_img_tags( $post_id ) {
 	$post = get_post( $post_id );
 	$w = get_option( 'external_image_whichimgs' );
-	$s = get_option( 'siteurl' );
+	$s = home_url();
 
 	$excludes = get_option( 'external_image_excludes' );
 	$excludes = explode( ',' , $excludes );


### PR DESCRIPTION
If Wordpress is installed in a subdirectory and/or the wp-content directory is moved out of the WP directory, then almost all images will register as external when using `get_option('siteurl')` or `site_url()`.

`home_url()` returns the website root rather than Wordpress install root, and fixes this issue for subdirectory installs.